### PR TITLE
Add Klaviyo newsletter signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ npm run dev
 ```
 
 The application will be available at `http://localhost:3000`.
+
+## Newsletter Signup
+
+The homepage includes a newsletter signup form that sends subscribers to Klaviyo.
+Create a `.env.local` file with the following variables:
+
+```bash
+KLAVIYO_PRIVATE_KEY=your_private_key
+KLAVIYO_LIST_ID=your_list_id
+```
+
+Restart the development server after adding environment variables.

--- a/components/NewsletterForm.js
+++ b/components/NewsletterForm.js
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+export default function NewsletterForm() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState('idle');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('loading');
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      if (res.ok) {
+        setStatus('success');
+        setEmail('');
+      } else {
+        setStatus('error');
+      }
+    } catch (err) {
+      setStatus('error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col items-center gap-3">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        placeholder="Enter your email"
+        className="px-3 py-2 text-black rounded"
+      />
+      <button
+        type="submit"
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+        disabled={status === 'loading'}
+      >
+        Sign Up
+      </button>
+      {status === 'success' && (
+        <p className="text-green-500">Thanks for signing up!</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-500">Something went wrong. Please try again.</p>
+      )}
+    </form>
+  );
+}

--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -1,0 +1,39 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  const apiKey = process.env.KLAVIYO_PRIVATE_KEY;
+  const listId = process.env.KLAVIYO_LIST_ID;
+
+  if (!apiKey || !listId) {
+    return res.status(500).json({ error: 'Klaviyo environment variables not set' });
+  }
+
+  try {
+    const response = await fetch(`https://a.klaviyo.com/api/v2/list/${listId}/subscribe`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        api_key: apiKey,
+        profiles: [{ email }],
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return res.status(response.status).json({ error: text });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    return res.status(500).json({ error: 'Failed to subscribe' });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import NewsletterForm from '../components/NewsletterForm';
 
 export default function Home() {
   return (
@@ -9,9 +10,10 @@ export default function Home() {
         width={300}
         height={300}
       />
-      <h1 className="mt-4 text-4xl font-normal text-[#ffe717]">
-        Welcome to DrewCleaver.com
-      </h1>
+        <h1 className="mt-4 text-4xl font-normal text-[#ffe717]">
+          Welcome to DrewCleaver.com
+        </h1>
+        <NewsletterForm />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Klaviyo newsletter form component and API route
- display the new form on the homepage
- document new environment variables for Klaviyo

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858674ce26c8330b10aab1336156545