### PR TITLE
Add three-option theme toggle

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -3,7 +3,7 @@ import { FaLinkedin, FaTwitter, FaInstagram } from 'react-icons/fa';
 
 export default function Footer() {
   return (
-    <footer className="bg-black text-[#ffe717] py-6 mt-auto">
+    <footer className="bg-[var(--bg-color)] text-[var(--text-color)] py-6 mt-auto">
       <div className="container mx-auto flex flex-col items-center md:flex-row md:justify-between gap-4">
         <nav className="flex gap-6">
           <Link href="/" className="hover:underline">
@@ -20,21 +20,21 @@ export default function Footer() {
           <a
             href="https://www.linkedin.com/"
             aria-label="LinkedIn"
-            className="hover:text-[#ffe717]"
+            className="hover:text-[var(--hover-color)]"
           >
             <FaLinkedin />
           </a>
           <a
             href="https://twitter.com/"
             aria-label="Twitter"
-            className="hover:text-[#ffe717]"
+            className="hover:text-[var(--hover-color)]"
           >
             <FaTwitter />
           </a>
           <a
             href="https://www.instagram.com/"
             aria-label="Instagram"
-            className="hover:text-[#ffe717]"
+            className="hover:text-[var(--hover-color)]"
           >
             <FaInstagram />
           </a>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Link from 'next/link';
+import ThemeToggle from './ThemeToggle';
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
@@ -7,7 +8,7 @@ export default function Navbar() {
   const toggleMenu = () => setIsOpen(!isOpen);
 
   return (
-    <nav className="bg-black text-[#ffe717] border-b border-[#ffe717]">
+    <nav className="bg-[var(--bg-color)] text-[var(--text-color)] border-b border-[var(--border-color)]">
       <div className="mx-auto flex max-w-4xl items-center justify-between p-4">
         <Link href="/" className="text-xl font-bold">
           DrewCleaver.com
@@ -42,6 +43,7 @@ export default function Navbar() {
           <Link href="/contact" className="hover:underline">
             Contact
           </Link>
+          <ThemeToggle />
         </div>
       </div>
       {isOpen && (
@@ -55,6 +57,7 @@ export default function Navbar() {
           <Link href="/contact" className="hover:underline" onClick={toggleMenu}>
             Contact
           </Link>
+          <ThemeToggle />
         </div>
       )}
     </nav>

--- a/components/ThemeContext.js
+++ b/components/ThemeContext.js
@@ -1,0 +1,34 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext({ theme: 'canary', setTheme: () => {} });
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('canary');
+
+  // Load theme from localStorage on mount
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  // Apply theme class and persist preference
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.remove('theme-canary', 'theme-white', 'theme-light');
+      document.documentElement.classList.add(`theme-${theme}`);
+    }
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', theme);
+    }
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -1,0 +1,35 @@
+import { useTheme } from './ThemeContext';
+import { FaRegLightbulb, FaMoon, FaSun } from 'react-icons/fa';
+
+const themes = ['canary', 'white', 'light'];
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const cycleTheme = () => {
+    const current = themes.indexOf(theme);
+    const next = themes[(current + 1) % themes.length];
+    setTheme(next);
+  };
+
+  const icon = () => {
+    switch (theme) {
+      case 'white':
+        return <FaMoon />;
+      case 'light':
+        return <FaSun />;
+      default:
+        return <FaRegLightbulb />;
+    }
+  };
+
+  return (
+    <button
+      onClick={cycleTheme}
+      aria-label="Toggle theme"
+      className="p-2 rounded hover:bg-[var(--hover-color)] hover:text-[var(--bg-color)]"
+    >
+      {icon()}
+    </button>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,12 @@
 import '../styles/globals.css';
 import Navbar from '../components/Navbar';
+import { ThemeProvider } from '../components/ThemeContext';
 
 export default function App({ Component, pageProps }) {
   return (
-    <>
+    <ThemeProvider>
       <Navbar />
       <Component {...pageProps} />
-    </>
+    </ThemeProvider>
   );
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -2,7 +2,7 @@ import Footer from '../components/Footer';
 
 export default function About() {
   return (
-    <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
+    <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
       <main className="flex flex-grow flex-col items-center justify-center">
         <h1 className="text-4xl">About Page</h1>
       </main>

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -2,7 +2,7 @@ import Footer from '../components/Footer';
 
 export default function Contact() {
   return (
-    <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
+    <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
       <main className="flex flex-grow flex-col items-center justify-center">
         <h1 className="text-4xl">Contact Page</h1>
       </main>

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,7 @@ import Footer from '../components/Footer';
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
+    <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
       <Head>
         <title>Drew Cleaver Consulting | Political Strategy, Business Automation, Spiritual Insight</title>
         <meta

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,10 +4,38 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap');
 
+:root {
+  --bg-color: #000000;
+  --text-color: #ffe717;
+  --border-color: #ffe717;
+  --hover-color: #ffe717;
+}
+
+.theme-canary {
+  --bg-color: #000000;
+  --text-color: #ffe717;
+  --border-color: #ffe717;
+  --hover-color: #ffe717;
+}
+
+.theme-white {
+  --bg-color: #000000;
+  --text-color: #ffffff;
+  --border-color: #ffffff;
+  --hover-color: #ffffff;
+}
+
+.theme-light {
+  --bg-color: #f5f5f4; /* Soft white */
+  --text-color: #000000;
+  --border-color: #000000;
+  --hover-color: #000000;
+}
+
 html, body {
-    font-family: 'Roboto Mono', monospace;
-    background-color: #000000; /* Black background */
-    color: #ffe717; /* Canary color for text */
+  font-family: 'Roboto Mono', monospace;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 /* Scrollbar styling */


### PR DESCRIPTION
## Summary
- implement `ThemeProvider` and `ThemeToggle` to cycle between canary, white, and light themes
- manage colors through CSS variables for easy theming
- update Navbar and Footer to use theme colors and include toggle
- apply theme classes across pages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68587a503de08330a648cfa2b0caf6f5