### PR TITLE
Add SEO component with Open Graph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ KLAVIYO_LIST_ID=your_list_id
 ```
 
 Restart the development server after adding environment variables.
+
+## SEO Component
+
+The `SEO` component in `components/SEO.js` centralizes all meta tags for each
+page. It provides sensible defaults for title, description, keywords and the
+Open Graph image so the site is optimized when shared on LinkedIn, Instagram and
+GitHub. Pass custom values per page or rely on the built‑in fallbacks.

--- a/components/SEO.js
+++ b/components/SEO.js
@@ -1,0 +1,44 @@
+import Head from 'next/head';
+
+const defaultMeta = {
+  title:
+    'Drew Cleaver Consulting | Political Strategy, Business Automation, Spiritual Insight',
+  description:
+    'Drew Cleaver Consulting offers expert political strategy, business automation, and spiritual insight to help organizations thrive.',
+  keywords:
+    'Drew Cleaver Consulting, political strategy, business automation, spiritual insight',
+  image: '/DrewCconsultingLOGOcanary.png',
+  url: 'https://drewcleaver.com',
+};
+
+export default function SEO({
+  title = defaultMeta.title,
+  description = defaultMeta.description,
+  keywords = defaultMeta.keywords,
+  image = defaultMeta.image,
+  url = defaultMeta.url,
+}) {
+  const imageUrl = image.startsWith('http') ? image : `${url}${image}`;
+
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta name="keywords" content={keywords} />
+
+      {/* Open Graph / LinkedIn / Instagram / GitHub */}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={imageUrl} />
+      <meta property="og:url" content={url} />
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Drew Cleaver Consulting" />
+
+      {/* Twitter - also used by some platforms */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={imageUrl} />
+    </Head>
+  );
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,8 +1,10 @@
 import Footer from '../components/Footer';
+import SEO from '../components/SEO';
 
 export default function About() {
   return (
     <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
+      <SEO title="About - Drew Cleaver Consulting" />
       <main className="flex flex-grow flex-col items-center justify-center">
         <h1 className="text-4xl">About Page</h1>
       </main>

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,8 +1,10 @@
 import Footer from '../components/Footer';
+import SEO from '../components/SEO';
 
 export default function Contact() {
   return (
     <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
+      <SEO title="Contact - Drew Cleaver Consulting" />
       <main className="flex flex-grow flex-col items-center justify-center">
         <h1 className="text-4xl">Contact Page</h1>
       </main>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,22 +1,12 @@
 import Image from 'next/image';
-import Head from 'next/head';
+import SEO from '../components/SEO';
 import NewsletterForm from '../components/NewsletterForm';
 import Footer from '../components/Footer';
 
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
-      <Head>
-        <title>Drew Cleaver Consulting | Political Strategy, Business Automation, Spiritual Insight</title>
-        <meta
-          name="description"
-          content="Drew Cleaver Consulting offers expert political strategy, business automation, and spiritual insight to help organizations thrive."
-        />
-        <meta
-          name="keywords"
-          content="Drew Cleaver Consulting, political strategy, business automation, spiritual insight"
-        />
-      </Head>
+      <SEO />
 
       <main className="flex flex-col flex-grow items-center justify-center gap-4 sm:gap-6 p-4 sm:p-8">
         <header aria-labelledby="main-title" className="text-center">


### PR DESCRIPTION
## Summary
- create `SEO` component for Next.js meta tags
- integrate `SEO` across pages
- document SEO usage in README

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68587acd4fdc8330a5f78805d0495138