### PR TITLE
Connect newsletter form to Klaviyo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ This repository contains the scaffolding for **drewcleaver.com** built with [Nex
 ```bash
 npm install
 npm run dev
+```
+
+### Environment variables
+
+Create a `.env.local` file and add the Klaviyo credentials used by the newsletter signup form:
+
+```
+KLAVIYO_PRIVATE_KEY=your_private_key
+KLAVIYO_LIST_ID=your_list_id
+```

--- a/lib/klaviyo.js
+++ b/lib/klaviyo.js
@@ -1,0 +1,17 @@
+export async function subscribeToList({ email, listId, apiKey }) {
+  const response = await fetch(`https://a.klaviyo.com/api/v2/list/${listId}/subscribe`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      api_key: apiKey,
+      profiles: [{ email }],
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text);
+  }
+  return await response.json();
+}

--- a/pages/api/subscribe.js
+++ b/pages/api/subscribe.js
@@ -1,3 +1,5 @@
+import { subscribeToList } from '../../lib/klaviyo';
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -16,22 +18,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    const response = await fetch(`https://a.klaviyo.com/api/v2/list/${listId}/subscribe`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        api_key: apiKey,
-        profiles: [{ email }],
-      }),
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      return res.status(response.status).json({ error: text });
-    }
-
+    await subscribeToList({ email, listId, apiKey });
     return res.status(200).json({ success: true });
   } catch (err) {
     return res.status(500).json({ error: 'Failed to subscribe' });


### PR DESCRIPTION
## Summary
- add `subscribeToList` helper for Klaviyo API calls
- wire `/api/subscribe` to use the helper
- document required Klaviyo environment variables

## Testing
- `npm run test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68681e17443c8330a6b5c29b3d9ef060