### PR TITLE
Integrate Plausible analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "autoprefixer": "10.4.19",
         "next": "13.4.19",
+        "next-plausible": "^3.12.4",
         "postcss": "8.4.38",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2048,6 +2049,20 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-plausible": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.4.tgz",
+      "integrity": "sha512-cD3+ixJxf8yBYvsideTxqli3fvrB7R4BXcvsNJz8Sm2X1QN039WfiXjCyNWkub4h5++rRs6fHhchUMnOuJokcg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 ",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/next-sitemap": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "autoprefixer": "10.4.19",
     "next": "13.4.19",
+    "next-plausible": "^3.12.4",
     "postcss": "8.4.38",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import { ThemeProvider } from '../components/ThemeContext';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
+import PlausibleProvider from 'next-plausible';
 import * as gtag from '../lib/gtag';
 
 export default function App({ Component, pageProps }) {
@@ -20,18 +21,19 @@ export default function App({ Component, pageProps }) {
   }, [router.events]);
 
   return (
-    <ThemeProvider>
-      <Navbar />
-      <Component {...pageProps} />
+    <PlausibleProvider domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}>
+      <ThemeProvider>
+        <Navbar />
+        <Component {...pageProps} />
 
-      {gtag.GA_MEASUREMENT_ID && (
-        <>
-          <Script
-            src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_MEASUREMENT_ID}`}
-            strategy="afterInteractive"
-          />
-          <Script id="gtag-init" strategy="afterInteractive">
-            {`
+        {gtag.GA_MEASUREMENT_ID && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_MEASUREMENT_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="gtag-init" strategy="afterInteractive">
+              {`
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
@@ -39,9 +41,10 @@ export default function App({ Component, pageProps }) {
                 page_path: window.location.pathname,
               });
             `}
-          </Script>
-        </>
-      )}
-    </ThemeProvider>
+            </Script>
+          </>
+        )}
+      </ThemeProvider>
+    </PlausibleProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add `next-plausible` dependency
- wrap app with `PlausibleProvider` for privacy-focused analytics

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68681dfcb0608330b154ac4f498e570c