### PR TITLE
Connect ConvertKit signup form

### DIFF
--- a/components/EmailSignup.js
+++ b/components/EmailSignup.js
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react';
+
+export default function EmailSignup() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const script = document.createElement('script');
+    script.src = 'https://drewcleaver.kit.com/f122a238d5/index.js';
+    script.async = true;
+    script.setAttribute('data-uid', 'f122a238d5');
+    containerRef.current.appendChild(script);
+  }, []);
+
+  return <div ref={containerRef} className="flex justify-center" />;
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import SEO from '../components/SEO';
 import Footer from '../components/Footer';
-import EmailSignupPlaceholder from '../components/EmailSignupPlaceholder';
+import EmailSignup from '../components/EmailSignup';
 
 export default function Home() {
   return (
@@ -58,7 +58,7 @@ export default function Home() {
         </div>
 
         <div className="mt-6 w-full max-w-xs sm:max-w-sm">
-          <EmailSignupPlaceholder />
+          <EmailSignup />
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- add new `EmailSignup` component to embed a ConvertKit script for capturing emails
- use `EmailSignup` on the homepage instead of the placeholder

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68682e361dc4833081852c8cad6b900f