### PR TITLE
Update homepage button hover styles

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -6,7 +6,7 @@ import EmailSignup from '../components/EmailSignup';
 
 export default function Home() {
   const buttonClass =
-    'w-full text-center border-2 rounded py-2 transition-colors border-[#ffe717] text-[#ffe717] hover:bg-emerald-500 hover:text-black';
+    'w-full text-center border-2 rounded py-2 transition-colors duration-200 border-[#FFE717] bg-black text-[#FFE717] hover:bg-[#FFE717] hover:text-black';
   return (
     <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
       <SEO


### PR DESCRIPTION
## Summary
- tweak homepage button classes so the default state is black with yellow text/border and hover switches to yellow with black text

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683bd484e883308070746da5183e26