### PR TITLE
Add writing subscription button

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -63,6 +63,9 @@ export default function Home() {
           >
             GitHub
           </a>
+          <a href="https://drewcleaver.kit.com/f122a238d5" className={buttonClass}>
+            Unlock My Best Writing
+          </a>
           <Link href="/resume" className={buttonClass}>
             View Résumé
           </Link>


### PR DESCRIPTION
## Summary
- add button linking to Kit.com writing subscription

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6868442ed4a08330b5861d97b5dc6aac