### PR TITLE
Update homepage writing button link

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -63,8 +63,13 @@ export default function Home() {
           >
             GitHub
           </a>
-          <a href="https://drewcleaver.kit.com/f122a238d5" className={buttonClass}>
-            Unlock My Best Writing
+          <a
+            href="https://drewcleaver.kit.com/products/lifetime-sub"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={buttonClass}
+          >
+            Unlock Lifetime Writing Access
           </a>
           <Link href="/resume" className={buttonClass}>
             View Résumé


### PR DESCRIPTION
## Summary
- update the writing button text
- change the link to the lifetime subscription page
- open link in a new tab securely

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686849dd4f7c8330a9f71d7fd107475f