### PR TITLE
Resize nav domain and show in footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -55,6 +55,7 @@ export default function Footer() {
           </a>
         </div>
       </div>
+      <p className="mt-4 text-sm font-normal">DrewCleaver.com</p>
     </footer>
   );
 }

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -10,7 +10,7 @@ export default function Navbar() {
   return (
     <nav className="bg-[var(--bg-color)] text-[var(--text-color)] border-b border-[var(--border-color)]">
       <div className="mx-auto flex max-w-4xl items-center justify-between p-4">
-        <Link href="/" className="text-xl font-bold">
+        <Link href="/" className="hidden md:block text-lg font-normal">
           DrewCleaver.com
         </Link>
         <button


### PR DESCRIPTION
## Summary
- shrink navbar branding and hide on mobile
- display the DrewCleaver.com domain in the footer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68684dfdde2c83309b5e8a1cb7d30d0e