### PR TITLE
Center social links under email signup

### DIFF
--- a/components/SocialLinks.js
+++ b/components/SocialLinks.js
@@ -3,7 +3,7 @@ import { SiLinktree } from 'react-icons/si';
 
 export default function SocialLinks({ className = '' }) {
   return (
-    <div className={`flex gap-6 ${className}`.trim()}>
+    <div className={`flex justify-center gap-6 ${className}`.trim()}>
       <a
         href="https://www.linkedin.com/"
         aria-label="LinkedIn"

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import SEO from '../components/SEO';
 import Footer from '../components/Footer';
 import EmailSignup from '../components/EmailSignup';
+import SocialLinks from '../components/SocialLinks';
 
 export default function Home() {
   const buttonClass =
@@ -79,6 +80,8 @@ export default function Home() {
         <div className="mt-6 w-full max-w-xs sm:max-w-sm">
           <EmailSignup />
         </div>
+
+        <SocialLinks className="w-full text-2xl mt-4" />
       </main>
 
       <Footer />


### PR DESCRIPTION
## Summary
- center icons in `SocialLinks` component
- display social icons directly below the email signup on the homepage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68684e44389c833088cb7cc99fc427c1