### PR TITLE
Add centered social icons below signup forms

### DIFF
--- a/components/KitDownloadSignup.js
+++ b/components/KitDownloadSignup.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import SocialLinks from './SocialLinks';
 
 export default function KitDownloadSignup() {
   const containerRef = useRef(null);
@@ -35,16 +36,17 @@ export default function KitDownloadSignup() {
   return (
     <div className="flex flex-col items-center gap-4">
       <div ref={containerRef} className="w-full" />
-        {submitted && (
-          <a
-            href="/Cleaver-Drew-Resume-ATX-Public-2025.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={buttonClass}
-          >
-            Download Résumé
-          </a>
-        )}
+      {submitted && (
+        <a
+          href="/Cleaver-Drew-Resume-ATX-Public-2025.pdf"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonClass}
+        >
+          Download Résumé
+        </a>
+      )}
+      <SocialLinks className="justify-center mt-2 text-2xl" />
     </div>
   );
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import SEO from '../components/SEO';
 import Footer from '../components/Footer';
 import EmailSignup from '../components/EmailSignup';
+import SocialLinks from '../components/SocialLinks';
 
 export default function Home() {
   const buttonClass =
@@ -78,6 +79,7 @@ export default function Home() {
 
         <div className="mt-6 w-full max-w-xs sm:max-w-sm">
           <EmailSignup />
+          <SocialLinks className="justify-center mt-4 text-2xl" />
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- import `SocialLinks` on home page
- display social link icons centered beneath the email signup
- import and insert `SocialLinks` in the resume download form

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68684e3e9ac08330b6270dc96b23992f