### PR TITLE
Add centered logo

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import ThemeToggle from './ThemeToggle';
 
 export default function Navbar() {
@@ -9,12 +10,19 @@ export default function Navbar() {
 
   return (
     <nav className="bg-[var(--bg-color)] text-[var(--text-color)] border-b border-[var(--border-color)]">
-      <div className="mx-auto flex max-w-4xl items-center justify-between p-4">
-        <Link href="/" className="text-xl font-bold">
-          DrewCleaver.com
+      <div className="relative mx-auto flex max-w-4xl items-center justify-center p-4">
+        <Link href="/" className="absolute left-1/2 -translate-x-1/2 flex items-center" aria-label="Home">
+          <Image
+            src="/DrewCconsultingLOGOcanary.png"
+            alt="Drew Cleaver Consulting logo"
+            width={120}
+            height={120}
+            className="h-8 w-auto sm:h-10"
+            priority
+          />
         </Link>
         <button
-          className="md:hidden focus:outline-none"
+          className="absolute right-4 top-1/2 -translate-y-1/2 md:hidden focus:outline-none"
           onClick={toggleMenu}
           aria-label="Toggle navigation"
         >
@@ -33,7 +41,7 @@ export default function Navbar() {
             />
           </svg>
         </button>
-        <div className="hidden md:flex space-x-6">
+        <div className="hidden md:flex space-x-6 absolute right-4 top-1/2 -translate-y-1/2 items-center">
           <Link href="/" className="hover:underline">
             Home
           </Link>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -16,7 +16,7 @@ export default function Home() {
       />
 
       <main className="flex flex-col flex-grow items-center justify-center gap-6 p-4 sm:p-8">
-        <header aria-labelledby="main-title" className="text-center">
+        <header aria-labelledby="main-title" className="flex flex-col items-center text-center">
           <Image
             src="/DrewCconsultingLOGOcanary.png"
             alt="Drew Cleaver Consulting logo"


### PR DESCRIPTION
## Summary
- show the site logo image in the Navbar and center it
- keep the homepage header aligned with flex utilities

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68684e1640e0833083d3a2e983623a5e