### PR TITLE
Center social icons and simplify footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,60 +1,18 @@
 import Link from 'next/link';
-import { FaLinkedin, FaInstagram, FaGithub, FaLink } from 'react-icons/fa';
 
 export default function Footer() {
   return (
     <footer className="bg-[var(--bg-color)] text-[var(--text-color)] py-6 mt-auto text-sm">
-      <div className="container mx-auto flex flex-col items-center justify-center gap-4 md:flex-row md:gap-8">
-        <nav className="flex gap-6">
-          <Link href="/" className="hover:underline">
-            Home
-          </Link>
-          <Link href="/about" className="hover:underline">
-            About
-          </Link>
-          <Link href="/contact" className="hover:underline">
-            Contact
-          </Link>
-          <Link href="/privacy-policy" className="hover:underline">
-            Privacy Policy
-          </Link>
-          <Link href="/terms-of-service" className="hover:underline">
-            Terms of Service
-          </Link>
-        </nav>
-
-        <div className="flex gap-6 text-2xl">
-          <a
-            href="https://www.linkedin.com/in/drewcleaver/"
-            aria-label="LinkedIn"
-            className="hover:text-[var(--hover-color)]"
-          >
-            <FaLinkedin />
-          </a>
-          <a
-            href="https://github.com/drewcleaverdotcom"
-            aria-label="GitHub"
-            className="hover:text-[var(--hover-color)]"
-          >
-            <FaGithub />
-          </a>
-          <a
-            href="https://www.instagram.com/drewcleaverdotcom/"
-            aria-label="Instagram"
-            className="hover:text-[var(--hover-color)]"
-          >
-            <FaInstagram />
-          </a>
-          <a
-            href="https://linktr.ee/drewcleaver"
-            aria-label="Linktree"
-            className="hover:text-[var(--hover-color)]"
-          >
-            <FaLink />
-          </a>
-        </div>
-      </div>
-      <p className="mt-4 text-sm font-normal">DrewCleaver.com</p>
+      <p className="text-center text-sm">
+        © 2025 Drew Cleaver ·{' '}
+        <Link href="/privacy-policy" className="hover:underline">
+          Privacy Policy
+        </Link>{' '}
+        ·{' '}
+        <Link href="/terms-of-service" className="hover:underline">
+          Terms
+        </Link>
+      </p>
     </footer>
   );
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -79,10 +79,8 @@ export default function Home() {
 
         <div className="mt-6 w-full max-w-xs sm:max-w-sm">
           <EmailSignup />
-          <SocialLinks className="justify-center mt-4 text-2xl" />
+          <SocialLinks className="mt-4 text-2xl" />
         </div>
-
-        <SocialLinks className="w-full text-2xl mt-4" />
       </main>
 
       <Footer />


### PR DESCRIPTION
## Summary
- move social links to appear directly below the email signup on the home page
- remove icons and navigation from the footer
- add simple footer text with privacy and terms links

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6868505f973c833085fa99c3dbe71fe8