### PR TITLE
Remove placeholder logo from homepage

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -18,22 +18,15 @@ export default function Home() {
 
       <main className="flex flex-col flex-grow items-center justify-center gap-6 p-4 sm:p-8">
         <header aria-labelledby="main-title" className="text-center">
-          <Image
-            src="/DrewCconsultingLOGOcanary.png"
-            alt="Drew Cleaver Consulting logo"
-            width={300}
-            height={300}
-            className="w-40 sm:w-56 md:w-72"
-          />
           <h1
             id="main-title"
-            className="mt-4 text-2xl sm:text-3xl md:text-4xl font-normal text-center"
+            className="text-2xl sm:text-3xl md:text-4xl font-normal text-center"
           >
             Founder. Strategist. Big Ideas Writer.
           </h1>
         </header>
 
-        <div className="flex w-full max-w-xs sm:max-w-sm flex-col gap-4 mt-4">
+        <div className="flex w-full max-w-xs sm:max-w-sm flex-col gap-4">
           <Link href="/about" className={buttonClass}>
             About Me
           </Link>


### PR DESCRIPTION
## Summary
- remove the homepage logo image
- tighten spacing after removing the image

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68685115717c8330b835b61ae0ff38da