### PR TITLE
Refine kit form layout

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -70,7 +70,7 @@ export default function Home() {
           </Link>
         </div>
 
-        <div className="mt-4 w-full max-w-xs sm:max-w-sm">
+        <div className="mt-2 w-full max-w-xs sm:max-w-sm">
           <EmailSignup />
           <SocialLinks className="mt-3 text-2xl" />
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,6 +38,19 @@ html, body {
   color: var(--text-color);
 }
 
+/* Reduce default ConvertKit embed spacing */
+.seva-form.formkit-form,
+.formkit-form,
+.ck_form {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.formkit-powered-by,
+.ck-powered-by {
+  margin-top: 0 !important;
+}
+
 /* Scrollbar styling */
 
 /* Webkit (Chrome, Safari, Edge) */


### PR DESCRIPTION
## Summary
- tighten default ConvertKit spacing in global styles
- reduce top margin before kit signup container on the homepage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68685611e2108330a791f9ec745f238d