### PR TITLE
Fix headline scaling

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -20,7 +20,7 @@ export default function Home() {
         <header aria-labelledby="main-title" className="text-center">
           <h1
             id="main-title"
-            className="text-xl sm:text-2xl md:text-3xl font-normal text-center"
+            className="text-xs sm:text-base md:text-2xl lg:text-3xl font-normal text-center"
           >
             Founder. Strategist. Big Ideas Writer.
           </h1>


### PR DESCRIPTION
## Summary
- tweak the main headline so it scales down for mobile

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686859196fd483308d6a9e9d5f7c2d77