### PR TITLE
Add OG metadata with new share image

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -1,12 +1,12 @@
 import Head from 'next/head';
 
 const defaultMeta = {
-  title: 'Drew Cleaver | Building Big Ideas For the Future',
+  title: 'Drew Cleaver | Founder. Strategist. Big Ideas Writer.',
   description:
-    'Drew Cleaver Consulting offers expert political strategy, business automation, and spiritual insight to help organizations thrive.',
+    'Big ideas. Deep clarity. Bold moves. I help people build what matters.',
   keywords:
-    'Drew Cleaver Consulting, political strategy, business automation, spiritual insight',
-  image: '/DrewCconsultingLOGOcanary.png',
+    'Drew Cleaver, strategy, writing, big ideas, clarity',
+  image: '/linkshareimage1200x630.png',
   url: 'https://drewcleaver.com',
 };
 
@@ -29,9 +29,11 @@ export default function SEO({
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={imageUrl} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
       <meta property="og:url" content={url} />
       <meta property="og:type" content="website" />
-      <meta property="og:site_name" content="Drew Cleaver Consulting" />
+      <meta property="og:site_name" content="Drew Cleaver" />
 
       {/* Twitter - also used by some platforms */}
       <meta name="twitter:card" content="summary_large_image" />

--- a/pages/404.js
+++ b/pages/404.js
@@ -5,7 +5,7 @@ import SEO from '../components/SEO';
 export default function Custom404() {
   return (
     <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
-      <SEO title="404 - Drew Cleaver | Building Big Ideas For the Future" />
+      <SEO title="404 - Drew Cleaver | Founder. Strategist. Big Ideas Writer." />
       <main className="flex flex-grow flex-col items-center justify-center text-center p-4 space-y-6">
         <h1 className="text-8xl font-bold">404</h1>
         <p className="text-2xl max-w-md">Sorry, the page you are looking for does not exist.</p>

--- a/pages/about.js
+++ b/pages/about.js
@@ -5,7 +5,7 @@ import SEO from '../components/SEO';
 export default function About() {
   return (
     <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
-      <SEO title="About - Drew Cleaver | Building Big Ideas For the Future" />
+      <SEO title="About - Drew Cleaver | Founder. Strategist. Big Ideas Writer." />
       <main className="container mx-auto flex-grow p-4 flex flex-col gap-8">
         <h1 className="text-4xl sm:text-5xl font-normal">About Me</h1>
 

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -5,7 +5,7 @@ import ContactForm from '../components/ContactForm';
 export default function Contact() {
   return (
     <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
-      <SEO title="Contact - Drew Cleaver | Building Big Ideas For the Future" />
+      <SEO title="Contact - Drew Cleaver | Founder. Strategist. Big Ideas Writer." />
       <main className="flex flex-grow flex-col items-center justify-center gap-6 p-4">
         <h1 className="text-4xl">Contact</h1>
         <ContactForm />

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -11,9 +11,9 @@ export default function Home() {
   return (
     <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
       <SEO
-        title="Drew Cleaver | Building Big Ideas For the Future"
-        description="Drew Cleaver Consulting offers expert political strategy, business automation, and spiritual insight to help organizations thrive."
-        keywords="Drew Cleaver Consulting, political strategy, business automation, spiritual insight"
+        title="Drew Cleaver | Founder. Strategist. Big Ideas Writer."
+        description="Big ideas. Deep clarity. Bold moves. I help people build what matters."
+        keywords="Drew Cleaver, strategy, writing, big ideas, clarity"
       />
 
       <main className="flex flex-col flex-grow items-center justify-center gap-4 p-4 sm:p-6 pb-8 sm:pb-12">

--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -14,7 +14,7 @@ export async function getStaticProps() {
 export default function PrivacyPolicy({ content }) {
   return (
     <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
-      <SEO title="Privacy Policy - Drew Cleaver | Building Big Ideas For the Future" />
+      <SEO title="Privacy Policy - Drew Cleaver | Founder. Strategist. Big Ideas Writer." />
       <main className="container mx-auto flex-grow p-4 prose prose-invert">
         <ReactMarkdown>{content}</ReactMarkdown>
       </main>

--- a/pages/resume.js
+++ b/pages/resume.js
@@ -5,7 +5,7 @@ import KitDownloadSignup from '../components/KitDownloadSignup';
 export default function Resume() {
   return (
     <div className="flex min-h-screen flex-col bg-[var(--bg-color)] text-[var(--text-color)]">
-      <SEO title="Résumé - Drew Cleaver | Building Big Ideas For the Future" />
+      <SEO title="Résumé - Drew Cleaver | Founder. Strategist. Big Ideas Writer." />
       <main className="flex flex-col flex-grow items-center p-4 text-center gap-6">
         <h1 className="text-4xl">Résumé</h1>
         <p className="max-w-md">

--- a/pages/terms-of-service.js
+++ b/pages/terms-of-service.js
@@ -14,7 +14,7 @@ export async function getStaticProps() {
 export default function TermsOfService({ content }) {
   return (
     <div className="flex min-h-screen flex-col bg-black text-[#ffe717]">
-      <SEO title="Terms of Service - Drew Cleaver | Building Big Ideas For the Future" />
+      <SEO title="Terms of Service - Drew Cleaver | Founder. Strategist. Big Ideas Writer." />
       <main className="container mx-auto flex-grow p-4 prose prose-invert">
         <ReactMarkdown>{content}</ReactMarkdown>
       </main>


### PR DESCRIPTION
## Summary
- add `linkshareimage1200x630.png` as the default Open Graph image
- update SEO component with new site branding and share image
- update page metadata titles and descriptions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68686b8c754c8330a42587c5db3dfce8